### PR TITLE
Argumentliste og opplegg for enhetstesting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,4 +13,20 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+    </dependencies>
+
+
 </project>

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -1,19 +1,31 @@
 package controller;
 
+import model.CommandList;
+import util.ArgumentExtractor;
+
 public class Controller {
 
     public Controller(String[] args) {
         if (isArgument(args)){
             // TODO: Benytte argumentene som ble sendt med slik at bruker får det slik som h*n vil
                 // Eksempel: argument -h skal vise hjelpetekst i konsoll.
+            doConjecture(args);
+
         } else {
             // TODO: Bruker skal kunne konfigurere innstillingene selv.
             System.out.print("Ingen argumenter ble sendt med.");
         }
     }
 
+    private void doConjecture(String[] args) {
+        CommandList cmdList = ArgumentExtractor.extractToCommandList(args);
+
+        System.out.println("Kommandoliste laget. Her kommer kommandoene:");
+        System.out.println(cmdList);
+    }
+
     private boolean isArgument(String[] args) {
-        return args.length < 0 ? true : false;
+        return args.length > 0;
     }
 
 }

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -1,5 +1,7 @@
 package controller;
 
+import exceptions.ArgumentNotImplementedExeption;
+import lib.EArguments;
 import model.CommandList;
 import util.ArgumentExtractor;
 
@@ -10,18 +12,32 @@ public class Controller {
             // TODO: Benytte argumentene som ble sendt med slik at bruker får det slik som h*n vil
                 // Eksempel: argument -h skal vise hjelpetekst i konsoll.
             doConjecture(args);
-
         } else {
             // TODO: Bruker skal kunne konfigurere innstillingene selv.
-            System.out.print("Ingen argumenter ble sendt med.");
+            System.out.println("Ingen argumenter ble sendt med.");
         }
     }
 
     private void doConjecture(String[] args) {
-        CommandList cmdList = ArgumentExtractor.extractToCommandList(args);
+        try {
+            CommandList cmdList = ArgumentExtractor.extractToCommandList(args);
+            cmdList.forEach((command, arguments) -> {
+                runCommand(command, arguments);
+            });
+        } catch (ArgumentNotImplementedExeption exeption) {
+            System.err.print(exeption);
+        }
+    }
 
-        System.out.println("Kommandoliste laget. Her kommer kommandoene:");
-        System.out.println(cmdList);
+    private void runCommand(EArguments command, String[] args) {
+        switch (command) {
+            case HELP:
+                System.out.println("You need some help. Okey!");
+                break;
+            default:
+                System.out.println("Kjør default.");
+                break;
+        }
     }
 
     private boolean isArgument(String[] args) {

--- a/src/main/java/exceptions/ArgumentNotImplementedExeption.java
+++ b/src/main/java/exceptions/ArgumentNotImplementedExeption.java
@@ -1,0 +1,7 @@
+package exceptions;
+
+public class ArgumentNotImplementedExeption extends Exception {
+    public ArgumentNotImplementedExeption(String argument) {
+        super("\"" + argument + "\" er ikke et gyldig argument. For hjelp bruk argumentet \"-h\".");
+    }
+}

--- a/src/main/java/lib/EArguments.java
+++ b/src/main/java/lib/EArguments.java
@@ -1,0 +1,17 @@
+package lib;
+
+public enum EArguments {
+
+    HELP("-h");
+
+    private final String argument;
+
+    EArguments(String argument) {
+        this.argument = argument;
+    }
+
+    public String getArgument() {
+        return argument;
+    }
+
+}

--- a/src/main/java/model/CommandList.java
+++ b/src/main/java/model/CommandList.java
@@ -1,0 +1,14 @@
+package model;
+
+import lib.EArguments;
+
+import java.util.HashMap;
+import java.util.Properties;
+
+public class CommandList extends HashMap<EArguments, String[]> {
+
+    public void addCommand(EArguments arg, String[] values) {
+        put(arg, values);
+    }
+
+}

--- a/src/main/java/util/ArgumentExtractor.java
+++ b/src/main/java/util/ArgumentExtractor.java
@@ -1,0 +1,53 @@
+package util;
+
+import lib.EArguments;
+import model.CommandList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class ArgumentExtractor {
+
+    public static CommandList extractToCommandList(String[] args) {
+        CommandList cmdList = new CommandList();
+        for (int x = 0; x < args.length; x++) {
+            if (isFlag(args[x])) {
+                cmdList.addCommand(getFlagArgument(args[x]), getFlagChildren(args, x));
+            }
+        }
+        return cmdList;
+    }
+
+    private static String[] getFlagChildren(String[] args, int index) {
+        ArrayList<String> flagChildren = new ArrayList<String>();
+        boolean isFirstFlag = true;
+        for(int i = index; i < args.length; i++) {
+            if(isFlag(args[i]) && isFirstFlag) {
+                isFirstFlag = false;
+            } else if(isFlag(args[i]) && !isFirstFlag) {
+                break;
+            }
+            else {
+                flagChildren.add(args[i]);
+            }
+        }
+        return flagChildren.toArray(new String[flagChildren.size()]);
+    }
+
+    private static EArguments getFlagArgument(String argument) {
+        for (EArguments eArgument : EArguments.values()) {
+            System.out.println(eArgument.getArgument());
+            if(eArgument.getArgument().equals(argument))
+                return eArgument;
+
+        }
+        // TODO: Gjør noe lurt dersom argumentet ikke finnes.
+        return null;
+    }
+
+    private static boolean isFlag(String argument) {
+        return argument.startsWith("-");
+    }
+
+
+}

--- a/src/main/java/util/ArgumentExtractor.java
+++ b/src/main/java/util/ArgumentExtractor.java
@@ -1,14 +1,14 @@
 package util;
 
+import exceptions.ArgumentNotImplementedExeption;
 import lib.EArguments;
 import model.CommandList;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 
 public class ArgumentExtractor {
 
-    public static CommandList extractToCommandList(String[] args) {
+    public static CommandList extractToCommandList(String[] args) throws ArgumentNotImplementedExeption {
         CommandList cmdList = new CommandList();
         for (int x = 0; x < args.length; x++) {
             if (isFlag(args[x])) {
@@ -34,15 +34,13 @@ public class ArgumentExtractor {
         return flagChildren.toArray(new String[flagChildren.size()]);
     }
 
-    private static EArguments getFlagArgument(String argument) {
+    private static EArguments getFlagArgument(String argument) throws ArgumentNotImplementedExeption {
         for (EArguments eArgument : EArguments.values()) {
-            System.out.println(eArgument.getArgument());
             if(eArgument.getArgument().equals(argument))
                 return eArgument;
 
         }
-        // TODO: Gjør noe lurt dersom argumentet ikke finnes.
-        return null;
+        throw new ArgumentNotImplementedExeption(argument);
     }
 
     private static boolean isFlag(String argument) {

--- a/src/test/java/controller/ControllerTest.java
+++ b/src/test/java/controller/ControllerTest.java
@@ -1,0 +1,53 @@
+package controller;
+
+import exceptions.ArgumentNotImplementedExeption;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class ControllerTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+
+    @Before
+    public void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @After
+    public void killStreams() {
+        System.setOut(null);
+        System.setErr(null);
+    }
+
+    @Test
+    public void testMedIngenArgumenterGirVanligOppfoersel() {
+        String[] args = {};
+        Controller c = new Controller(args);
+        assertThat(outContent.toString(), is("Ingen argumenter ble sendt med.\r\n"));
+    }
+
+    @Test
+    public void testMedArgumenterGirVanligOppfoersel() {
+        String[] args = {"-h"};
+        Controller c = new Controller(args);
+        assertThat(outContent.toString(), is("You need some help. Okey!\r\n"));
+    }
+
+    @Test
+    public void testMedFeilArgumenterKasterException() {
+        String[] args = {"-etArgumentSomIkkeEksisterer"};
+        Controller c = new Controller(args);
+        assertTrue(errContent.toString().startsWith("exceptions.ArgumentNotImplementedExeption"));
+    }
+
+}


### PR DESCRIPTION
Nå kan man kjøre programmet med argumenter.
Det er ikke laget noe logikk for hvordan argumentene utføres, kun logikk for det å hente ut argumenter.
Lagde enhetstester for tre ting:
1. Starte programmet uten argumenter
2. Starte programmet med et argument som finnes (akkurat nå er det kun -h)
3. Starte programmet med et argument som ikke finnes (-etTeitArgumentSomIkkeErImplementert)