### PR TITLE
Maven Dependency Checks.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
+        <junit.version>4.12</junit.version>
+        <hamcrest.version>1.3</hamcrest.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
@@ -17,16 +19,40 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.9.0</version>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
         </dependency>
+
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Plugin for å sjekke alle avhengigheter. Nekter å bygge dersom det er noe feil -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 
 </project>


### PR DESCRIPTION
Sjekker alle avhengigheter som er brukt i prosjektet. 
Dersom det er brukt en avhengighet som ikke er nevnt i pom.xml, vil bygget feile. 
Samme andre veien, hvis du har deklarert en avhengighet som ikke blir brukt.

Andre ting som er gjort:
- Fjernet Mockito (har ikke brukt det enda) - brukes til mocking under enhetstesting
- Versjoner i pom.xml er nå satt som variabler
